### PR TITLE
Change installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Clone the repository and symlink it with your `~/.config/nvim` directory with
 
 ``` bash
 git clone https://github.com/pgosar/CyberNvim
-ln -s ~/path/to/CyberNvim/nvim ~/.config/nvim
+ln -s ~/path/to/CyberNvim ~/.config/nvim
 ```
 
 Alternatively, directly clone it to the nvim folder:


### PR DESCRIPTION
The following modifications might be needed in `README.md` since there is no nvim directory in this repository.

Before:
```sh
ln -s ~/path/to/CyberNvim/nvim ~/.config/nvim
```

After
```
ln -s ~/path/to/CyberNvim ~/.config/nvim
```